### PR TITLE
BR-53 Update to require BREACH_NOTICE auth role

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,109 +8,6 @@ API back-end for the [HMPPS Breach Notice](https://github.com/ministryofjustice/
 
 # Instructions
 
-If this is a HMPPS project then the project will be created as part of bootstrapping -
-see [dps-project-bootstrap](https://github.com/ministryofjustice/dps-project-bootstrap). You are able to specify a
-template application using the `github_template_repo` attribute to clone without the need to manually do this yourself
-within GitHub.
-
-This project is community managed by the mojdt `#kotlin-dev` slack channel.
-Please raise any questions or queries there. Contributions welcome!
-
-Our security policy is located [here](https://github.com/ministryofjustice/hmpps-template-kotlin/security/policy).
-
-Documentation to create new service is located [here](https://tech-docs.hmpps.service.justice.gov.uk/applicationplatform/newservice-GHA/).
-
-## Creating a Cloud Platform namespace
-
-When deploying to a new namespace, you may wish to use the
-[templates project namespace](https://github.com/ministryofjustice/cloud-platform-environments/tree/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev)
-as the basis for your new namespace. This namespace contains both the kotlin and typescript template projects, 
-which is the usual way that projects are setup.
-
-Copy this folder and update all the existing namespace references to correspond to the environment to which you're deploying.
-
-If you only need the kotlin configuration then remove all typescript references and remove the elasticache configuration. 
-
-To ensure the correct github teams can approve releases, you will need to make changes to the configuration in `resources/service-account-github` where the appropriate team names will need to be added (based on [lines 98-100](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf#L98) and the reference appended to the teams list below [line 112](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-templates-dev/resources/serviceaccount-github.tf#L112)). Note: hmpps-sre is in this list to assist with deployment issues.
-
-Submit a PR to the Cloud Platform team in
-#ask-cloud-platform. Further instructions from the Cloud Platform team can be found in
-the [Cloud Platform User Guide](https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide)
-
-## Renaming from HMPPS Breach Notice Api - github Actions
-
-Once the new repository is deployed. Navigate to the repository in github, and select the `Actions` tab.
-Click the link to `Enable Actions on this repository`.
-
-Find the Action workflow named: `rename-project-create-pr` and click `Run workflow`. This workflow will
-execute the `rename-project.bash` and create Pull Request for you to review. Review the PR and merge.
-
-Note: ideally this workflow would run automatically however due to a recent change github Actions are not
-enabled by default on newly created repos. There is no way to enable Actions other then to click the button in the UI.
-If this situation changes we will update this project so that the workflow is triggered during the bootstrap project.
-Further reading: <https://github.community/t/workflow-isnt-enabled-in-repos-generated-from-template/136421>
-
-The script takes six arguments:
-
-### New project name
-
-This should start with `hmpps-` e.g. `hmpps-prison-visits` so that it can be easily distinguished in github from
-other departments projects. Try to avoid using abbreviations so that others can understand easily what your project is.
-
-### Slack channel for release notifications
-
-By default, release notifications are only enabled for production. The circleci configuration can be amended to send
-release notifications for deployments to other environments if required. Note that if the configuration is amended,
-the slack channel should then be amended to your own team's channel as `dps-releases` is strictly for production release
-notifications. If the slack channel is set to something other than `dps-releases`, production release notifications
-will still automatically go to `dps-releases` as well. This is configured by `releases-slack-channel` in
-`.circleci/config.yml`.
-
-### Slack channel for pipeline security notifications
-
-Ths channel should be specific to your team and is for daily / weekly security scanning job results. It is your team's
-responsibility to keep up-to-date with security issues and update your application so that these jobs pass. You will
-only be notified if the jobs fail. The scan results can always be found in circleci for your project. This is
-configured by `alerts-slack-channel` in `.circleci/config.yml`.
-
-### Non production kubernetes alerts
-
-By default Prometheus alerts are created in the application namespaces to monitor your application e.g. if your
-application is crash looping, there are a significant number of errors from the ingress. Since Prometheus runs in
-cloud platform AlertManager needs to be setup first with your channel. Please see
-[Create your own custom alerts](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html)
-in the Cloud Platform user guide. Once that is setup then the `custom severity label` can be used for
-`alertSeverity` in the `helm_deploy/values-*.yaml` configuration.
-
-Normally it is worth setting up two separate labels and therefore two separate slack channels - one for your production
-alerts and one for your non-production alerts. Using the same channel can mean that production alerts are sometimes
-lost within non-production issues.
-
-### Production kubernetes alerts
-
-This is the severity label for production, determined by the `custom severity label`. See the above
-#non-production-kubernetes-alerts for more information. This is configured in `helm_deploy/values-prod.yaml`.
-
-### Product ID
-
-This is so that we can link a component to a product and thus provide team and product information in the Developer
-Portal. Refer to the developer portal at https://developer-portal.hmpps.service.justice.gov.uk/products to find your
-product id. This is configured in `helm_deploy/<project_name>/values.yaml`.
-
-## Manually branding from template app
-
-Run the `rename-project.bash` without any arguments. This will prompt for the six required parameters and create a PR.
-The script requires a recent version of `bash` to be installed, as well as GNU `sed` in the path.
-
-## TODOs and Examples
-
-We have tried to provide some examples of best practice in the application - so there are lots of TODOs in the code
-where changes are required to meet your requirements. There is an `ExampleResource` that includes best practice and also
-serve as spring security examples. The template typescript project has a demonstration that calls this endpoint as well.
-
-For the demonstration, rather than introducing a dependency on a different service, this application calls out to
-itself. This is only to show a service calling out to another service and is certainly not recommended!
-
 ## Running the application locally
 
 The application comes with a `dev` spring profile that includes default settings for running locally. This is not
@@ -126,12 +23,21 @@ docker compose pull && docker compose up
 
 will build the application and run it and HMPPS Auth within a local docker instance.
 
-### Running the application in Intellij
+## Running the application in IntelliJ IDEA
 
 ```bash
 docker compose pull && docker compose up --scale hmpps-breach-notice-api=0
 ```
 
 will just start a docker instance of HMPPS Auth. The application should then be started with a `dev` active profile
-in Intellij.
+in IntelliJ.
 
+## Authentication
+
+All API endpoints require an OAuth2 client token from HMPPS Auth with the `BREACH_NOTICE` role.
+
+When running locally, there is a built-in client you can use that has the correct role:
+```properties
+CLIENT_ID=hmpps-breach-notice-ui-client
+CLIENT_SECRET=clientsecret
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,22 +11,22 @@ services:
       - hmpps
   hmpps-auth:
     image: quay.io/hmpps/hmpps-auth:latest
-    networks:
-      - hmpps
-    container_name: hmpps-auth
     ports:
-      - "8090:8080"
+      - "9090:8080"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
       - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+    networks:
+      - hmpps
   gotenberg:
     image: gotenberg/gotenberg:8
-    container_name: gotenberg
     ports:
       - "8072:3000"
+    networks:
+      - hmpps
 
 networks:
   hmpps:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/config/OpenApiConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/config/OpenApiConfiguration.kt
@@ -32,7 +32,7 @@ class OpenApiConfiguration(buildProperties: BuildProperties) {
     .components(
       Components().addSecuritySchemes(
         "breach-notice-api-ui-role",
-        SecurityScheme().addBearerJwtRequirement("ROLE_TEMPLATE_KOTLIN__UI"),
+        SecurityScheme().addBearerJwtRequirement("ROLE_BREACH_NOTICE"),
       ),
     )
     .addSecurityItem(SecurityRequirement().addList("breach-notice-api-ui-role", listOf("read")))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/controller/BreachNoticeController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/controller/BreachNoticeController.kt
@@ -29,8 +29,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 import java.util.*
 
 @RestController
-// Role here is specific to the UI.
-@PreAuthorize("hasRole('ROLE_TEMPLATE_KOTLIN__UI')")
+@PreAuthorize("hasRole('ROLE_BREACH_NOTICE')")
 @RequestMapping(value = ["/breach-notice"], produces = ["application/json"])
 class BreachNoticeController(private val breachNoticeService: BreachNoticeService) {
   @GetMapping("/{uuid}")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,14 +59,14 @@ management:
 
 ---
 spring.config.activate.on-profile: dev
-hmpps-auth.url: http://localhost:8090/auth
+hmpps-auth.url: http://localhost:9090/auth
 database.endpoint: localhost:5432
 frontend.url: http://localhost:3000
 gotenberg.url: http://localhost:8072
 
 ---
 spring.config.activate.on-profile: test
-hmpps-auth.url: http://localhost:8090/auth
+hmpps-auth.url: http://localhost:9090/auth
 frontend.url: http://localhost:3000
 gotenberg.url: http://localhost:8072
 spring.datasource:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/BreachNoticeCrudTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/BreachNoticeCrudTests.kt
@@ -18,7 +18,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `should create a breach notice`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00000B",
@@ -37,7 +37,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `should update a breach notice`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00001C",
@@ -77,7 +77,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
 
     webTestClient.put()
       .uri("/breach-notice/" + breachNotice.id)
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         breachNoticeBody,
       )
@@ -96,7 +96,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `should fail to create if the crn is too long`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00000B123456789123456",
@@ -111,7 +111,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `update should return server error if invalid format uuid passed in`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00001G",
@@ -126,7 +126,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
 
     webTestClient.put()
       .uri("/breach-notice/" + "testone")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         /* body = */
         BreachNotice(
@@ -163,7 +163,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `should delete a breach notice`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00001D",
@@ -179,7 +179,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
 
     webTestClient.delete()
       .uri("/breach-notice/" + breachNotice.first().id)
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .isOk
@@ -192,7 +192,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `error on delete a breach notice when no matching uuid`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00002D",
@@ -209,7 +209,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
     // Non-existent uuid
     webTestClient.delete()
       .uri("/breach-notice/" + "00000000-0000-4000-8000-000000000000")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .isNotFound
@@ -220,7 +220,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
     // Existing, now-deleted uuid
     webTestClient.delete()
       .uri("/breach-notice/" + breachNotice.first().id)
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .isOk
@@ -230,7 +230,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
 
     webTestClient.delete()
       .uri("/breach-notice/" + breachNotice.first().id)
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .isNotFound
@@ -240,7 +240,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
   fun `delete should return server error if invalid format uuid passed in`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00003D",
@@ -255,7 +255,7 @@ class BreachNoticeCrudTests : IntegrationTestBase() {
 
     webTestClient.delete()
       .uri("/breach-notice/" + "TESTONE")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .is5xxServerError

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/OpenApiDocsTest.kt
@@ -75,7 +75,7 @@ class OpenApiDocsTest : IntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @CsvSource(value = ["breach-notice-api-ui-role, ROLE_TEMPLATE_KOTLIN__UI"])
+  @CsvSource(value = ["breach-notice-api-ui-role, ROLE_BREACH_NOTICE"])
   fun `the security scheme is setup for bearer tokens`(key: String, role: String) {
     webTestClient.get()
       .uri("/v3/api-docs")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/PdfGenerationTests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/PdfGenerationTests.kt
@@ -20,7 +20,7 @@ class PdfGenerationTests : IntegrationTestBase() {
 
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00002A",
@@ -36,7 +36,7 @@ class PdfGenerationTests : IntegrationTestBase() {
 
     webTestClient.get()
       .uri("/breach-notice/" + breachNotice[0].id + "/pdf")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .isOk
@@ -50,7 +50,7 @@ class PdfGenerationTests : IntegrationTestBase() {
   fun `get PDF should return a 404 response if breach not found`() {
     webTestClient.post()
       .uri("/breach-notice")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .bodyValue(
         BreachNotice(
           crn = "X00002A",
@@ -65,7 +65,7 @@ class PdfGenerationTests : IntegrationTestBase() {
 
     webTestClient.get()
       .uri("/breach-notice/" + UUID.randomUUID() + "/pdf")
-      .headers(setAuthorisation(roles = listOf("ROLE_TEMPLATE_KOTLIN__UI")))
+      .headers(setAuthorisation(roles = listOf("ROLE_BREACH_NOTICE")))
       .exchange()
       .expectStatus()
       .is5xxServerError

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/breachnoticeapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -38,7 +38,7 @@ class HmppsAuthApiExtension :
 
 class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
   companion object {
-    private const val WIREMOCK_PORT = 8090
+    private const val WIREMOCK_PORT = 9090
   }
 
   fun stubGrantToken() {


### PR DESCRIPTION
Following this change, we'll need to use the `hmpps-breach-notice-ui-client` / `clientsecret` OAuth client for accessing the API (instead of the `hmpps-template-typescript-client` we're using currently).

You can switch to using the new client in three steps:

1. To get the new client, make sure to pull the latest HMPPS Auth image:
```shell
docker compose pull hmpps-auth
docker compose up -d hmpps-auth
```

2. Then, update your .env file in [hmpps-breach-notice-ui](https://github.com/ministryofjustice/hmpps-breach-notice-ui) with the following:
```properties
# Credentials for allowing user access
AUTH_CODE_CLIENT_ID=hmpps-breach-notice-ui
AUTH_CODE_CLIENT_SECRET=clientsecret

# Credentials for API calls
CLIENT_CREDS_CLIENT_ID=hmpps-breach-notice-ui-client
CLIENT_CREDS_CLIENT_SECRET=clientsecret
```
(example: https://github.com/ministryofjustice/hmpps-breach-notice-ui/blob/main/.env.example)

3. Additionally, if you're testing integration with NDelius, you should update the following environment variables for the Delius Docker configuration:
```properties
OAUTH_URL=http://localhost:9090/auth
API_CLIENT_ID=hmpps-breach-notice-ui-client
API_CLIENT_SECRET=clientsecret
```